### PR TITLE
improvement: grid for cards

### DIFF
--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -13,7 +13,7 @@ export default async function Slug({ params }: { params: { slug: string[] } }) {
 		<>
 			<Header title={data.title} description={data.description} />
 
-			<div className='grid gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-3 mt-8'>
+			<div className='grid gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-4 mt-8'>
 				{data.submenu.map(item => (
 					<Card key={item.imgPlaceholder} item={item} />
 				))}


### PR DESCRIPTION
# RecursosTech PR Template

## Descripcion ✏️

Las cards quedaron muy grandes con la grilla en 3 columnas, por lo que se mejoró cambiandolo a 3.

## Cambios visuales 🎨

antes:
![image](https://github.com/nsdonato/recursostech/assets/7875216/e97e8f6f-3a2c-4bc9-bfcf-42d467d1880b)

después:
![image](https://github.com/nsdonato/recursostech/assets/7875216/cd2d5c20-9cd4-48c0-a611-9cbaa42bd5ae)