### PR TITLE
style: adding gap in menu items

### DIFF
--- a/components/sidebar-menu/sidebar-menu.tsx
+++ b/components/sidebar-menu/sidebar-menu.tsx
@@ -17,7 +17,7 @@ export const SidebarMenu = async ({ className }: SidebarMenuProps) => {
 
 	return (
 		<nav className={className}>
-			<ul className='menu rounded-box shadow-lg'>
+			<ul className='menu rounded-box shadow-lg grid gap-1'>
 				{menu.map(menuItem => (
 					<li key={menuItem.name}>
 						{menuItem.name === MAIN_MENU ? (
@@ -25,7 +25,7 @@ export const SidebarMenu = async ({ className }: SidebarMenuProps) => {
 						) : (
 							<details open>
 								<summary>{menuItem.name}</summary>
-								<ul>
+								<ul className='grid gap-1'>
 									{menuItem.items?.length === 1 ? (
 										<SidebarMenuItem items={[]} />
 									) : (

--- a/components/sidebar-menu/sidebar-submenu-item.tsx
+++ b/components/sidebar-menu/sidebar-submenu-item.tsx
@@ -7,10 +7,10 @@ type SidebarSubMenuItemProps = {
 
 export const SidebarSubMenuItem = ({ submenu }: SidebarSubMenuItemProps) => {
 	return (
-		<li>
+		<li className='grid gap-1'>
 			<details>
 				<summary>{submenu.name}</summary>
-				<ul>
+				<ul className='grid gap-1'>
 					<SidebarMenuItem items={submenu.items} />
 				</ul>
 			</details>


### PR DESCRIPTION
# RecursosTech PR Template

## Descripcion ✏️

Se agrega grid y gap en la navegación para mejorar la visibilidad cuando se hace hover en los items

## Cambios visuales 🎨

Antes:
<img width="1403" alt="SCR-20240127-jrzg" src="https://github.com/nsdonato/recursostech/assets/42702720/b2be4dd0-2d05-4536-8bca-0a60343e0414">
Después:
<img width="1437" alt="SCR-20240127-jsgp" src="https://github.com/nsdonato/recursostech/assets/42702720/ef8d5159-4621-4db3-922b-9584ce7830f3">
