### PR TITLE
feat: show on index contributors from github

### DIFF
--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -3,24 +3,28 @@ import { Contributors } from '@/components/contributors/contributors'
 import { Divider } from '@/components/divider/divider'
 import { Header } from '@/components/header/header'
 import { getMenuItem } from '@/lib/mdx/get-menu-item'
+import { Contributor } from '@/lib/mdx/mdx-utils'
 
 export default async function Slug({ params }: { params: { slug: string[] } }) {
-	const { data } = await getMenuItem(params.slug)
+  const { data } = await getMenuItem(params.slug)
 
-	if (!data) return null
+  if (!data) return null
 
-	return (
-		<>
-			<Header title={data.title} description={data.description} />
+  return (
+    <>
+      <Header title={data.title} description={data.description} />
 
-			<div className='grid gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-4 mt-8'>
-				{data.submenu.map(item => (
-					<Card key={item.imgPlaceholder} item={item} />
-				))}
-			</div>
-			<Divider className='p-4' />
+      <div className='grid gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-4 mt-8'>
+        {data.submenu.map(item => (
+          <Card key={item.imgPlaceholder} item={item} />
+        ))}
+      </div>
+      <Divider className='p-4' />
 
-			<Contributors contributors={data?.contributors ?? []} />
-		</>
-	)
+      <Contributors
+        isIndex={false}
+        contributors={data?.contributors as Contributor[]}
+      />
+    </>
+  )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
+import { Analytics } from '@vercel/analytics/react'
 import type { Metadata } from 'next'
-import { Analytics } from '@vercel/analytics/react';
 
 import Navbar from '@/components/navbar/navbar'
 import { SidebarMenu } from '@/components/sidebar-menu/sidebar-menu'
@@ -9,28 +9,28 @@ import { getTheme } from '../lib/getTheme'
 import './globals.css'
 
 export const metadata: Metadata = {
-	title: 'Recursos Tech',
-	description: 'Recursos tech para la comunidad',
+  title: 'Recursos Tech',
+  description: 'Recursos tech para la comunidad',
 }
 
 export default function RootLayout({
-	children,
+  children,
 }: {
-	children: React.ReactNode
+  children: React.ReactNode
 }) {
-	return (
-		<html lang='es' className={'font-popi font-popi-light'}>
-			<head>
-				<script dangerouslySetInnerHTML={{ __html: getTheme }} />
-			</head>
-			<body>
-				<Navbar />
-				<div className='grid grid-cols-1 gap-4 lg:grid-cols-6'>
-					<SidebarMenu className='' />
-					<main className='p-4 lg:col-span-5'>{children}</main>
-				</div>
-				<Analytics />
-			</body>
-		</html>
-	)
+  return (
+    <html lang='es' className={'font-popi font-popi-light'}>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: getTheme }} />
+      </head>
+      <body>
+        <Navbar />
+        <div className='grid grid-cols-1 gap-4 lg:grid-cols-6'>
+          <SidebarMenu className='' />
+          <main className='p-4 lg:col-span-5'>{children}</main>
+        </div>
+        <Analytics />
+      </body>
+    </html>
+  )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,23 +7,23 @@ import { WebLink } from '@/components/web-link/web-link'
 import { getIndex } from '@/lib/mdx/get-index'
 
 export default async function Home() {
-	const { data, source } = await getIndex()
+  const { source } = await getIndex()
 
-	return (
-		<div>
-			<MDXRemote
-				source={source}
-				components={{
-					Figure,
-					li: props => <li className='' {...props} />,
-					ul: props => <ul className='list-disc pl-6' {...props} />,
-					p: props => <p className='py-4' {...props} />,
-					WebLink,
-					Header,
-				}}
-			/>
-			<div className='divider'></div>
-			<Contributors contributors={data?.contributors} />
-		</div>
-	)
+  return (
+    <div>
+      <MDXRemote
+        source={source}
+        components={{
+          Figure,
+          li: props => <li className='' {...props} />,
+          ul: props => <ul className='list-disc pl-6' {...props} />,
+          p: props => <p className='py-4' {...props} />,
+          WebLink,
+          Header,
+        }}
+      />
+      <div className='divider'></div>
+      <Contributors isIndex />
+    </div>
+  )
 }

--- a/components/contributors/contributors.test.tsx
+++ b/components/contributors/contributors.test.tsx
@@ -4,16 +4,20 @@ import { Contributors } from './contributors'
 
 // HOW TO TEST ASYNC COMPONENTS: https://github.com/vercel/next.js/issues/47131
 /**
- * @param {function} Component
+ * @param {(props: {}) => Promise<JSX.Element>} Component
  * @param {*} props
  * @returns {Promise<()=>JSX.Element>}
  */
-async function resolvedComponent(Component, props) {
+async function resolvedComponent(
+  Component: (props: {}) => Promise<JSX.Element>,
+  props: {}
+) {
   const ComponentResolved = await Component(props)
   return () => ComponentResolved
 }
 
 describe('<Contributors />', () => {
+  //@ts-ignore
   global.fetch = jest.fn(() =>
     Promise.resolve({
       ok: true,

--- a/components/contributors/contributors.test.tsx
+++ b/components/contributors/contributors.test.tsx
@@ -1,19 +1,62 @@
 import { render, screen } from '@testing-library/react'
 
-import { Contributor } from '@/lib/mdx/mdx-utils'
-
 import { Contributors } from './contributors'
 
+// HOW TO TEST ASYNC COMPONENTS: https://github.com/vercel/next.js/issues/47131
+/**
+ * @param {function} Component
+ * @param {*} props
+ * @returns {Promise<()=>JSX.Element>}
+ */
+async function resolvedComponent(Component, props) {
+  const ComponentResolved = await Component(props)
+  return () => ComponentResolved
+}
+
 describe('<Contributors />', () => {
-	test('renders correctly', () => {
-		const contributors: Contributor[] = [{ github_username: 'nsdonato' }]
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          {
+            id: 1,
+            login: 'nsdonato',
+            avatar_url: 'https://example.com/avatar1.jpg',
+            html_url: 'https://example.com/profile1',
+            contributions: 0,
+          },
+        ]),
+    })
+  )
 
-		render(<Contributors contributors={contributors} />)
-		const avatar = screen.getByRole('img', {
-			name: /nsdonato/i,
-		})
+  test('renders correctly from index', async () => {
+    const AsyncRscComponent = await resolvedComponent(Contributors, {
+      isIndex: true,
+    })
+    render(<AsyncRscComponent />)
 
-		expect(screen.getByText('Colaboradores')).toBeInTheDocument()
-		expect(avatar).toBeInTheDocument()
-	})
+    const avatar = screen.getByTestId('contributor-nsdonato')
+
+    expect(screen.getByText('Colaboradores')).toBeInTheDocument()
+    expect(
+      screen.getByText('Gracias a todxs los que aportaron en este proyecto ✨')
+    ).toBeInTheDocument()
+    expect(avatar).toBeInTheDocument()
+  })
+
+  test('renders correctly from slug', async () => {
+    const AsyncRscComponent = await resolvedComponent(Contributors, {
+      isIndex: false,
+      contributors: [
+        {
+          github_username: 'vamoacodear',
+        },
+      ],
+    })
+    render(<AsyncRscComponent />)
+
+    const avatar = screen.getByTestId('contributor-vamoacodear')
+    expect(avatar).toBeInTheDocument()
+  })
 })

--- a/components/contributors/contributors.tsx
+++ b/components/contributors/contributors.tsx
@@ -1,43 +1,54 @@
 import Image from 'next/image'
 
 import { Contributor } from '@/lib/mdx/mdx-utils'
+import { adaptContributorsFromMdx } from '@/services/github/adapters'
+import { getContributorsFromGitHub } from '@/services/github/get-contributors'
+
 import { WebLink } from '../web-link/web-link'
 
 type ContributorsProp = {
-	contributors: Contributor[] | []
+  contributors?: Contributor[]
+  isIndex?: boolean
 }
 
-export const Contributors = ({ contributors }: ContributorsProp) => {
-	if (!contributors?.length) {
-		return null
-	}
+export const Contributors = async ({
+  contributors = [],
+  isIndex = false,
+}: ContributorsProp) => {
+  let data = []
 
-	return (
-		<div className='card bg-base-100 shadow-lg ring-1 mt-4 p-4 w-fit'>
-			<h2 className='card-title mb-4 text-xl'>Colaboradores</h2>
-			<p className='mb-4'>
-				Gracias a todxs los que aportaron en este documento! ✨
-			</p>
-			<ul className='flex flex-wrap gap-2'>
-				{contributors.map(({ github_username }) => {
-					return (
-						<li key={`contributor-${github_username}`}>
-							<WebLink
-								href={`https://github.com/${github_username}`}
-								>
-								<Image
-									loading='lazy'
-									src={`https://github.com/${github_username}.png?size=80`}
-									width='40'
-									height='40'
-									alt={`Usuarix contribuidxr - ${github_username}`}
-									className='rounded-full'
-								/>
-							</WebLink>
-						</li>
-					)
-				})}
-			</ul>
-		</div>
-	)
+  if (isIndex) {
+    data = await getContributorsFromGitHub()
+  } else {
+    data = adaptContributorsFromMdx(contributors)
+  }
+
+  return (
+    <div className='card bg-base-100 shadow-lg ring-1 mt-4 p-4 w-fit'>
+      <h2 className='card-title mb-4 text-xl'>Colaboradores</h2>
+      <p className='mb-4'>
+        Gracias a todxs los que aportaron en este{' '}
+        {isIndex ? 'proyecto' : 'documento!'} ✨
+      </p>
+      <ul className='flex flex-wrap gap-2'>
+        {data.map(contributor => {
+          return (
+            <li key={`contributor-${contributor.name}`}>
+              <WebLink href={contributor.profile}>
+                <Image
+                  data-testid={`contributor-${contributor.name}`}
+                  loading='lazy'
+                  src={contributor.avatar}
+                  width='40'
+                  height='40'
+                  alt={`Usuarix contribuidxr - ${contributor.name}`}
+                  className='rounded-full'
+                />
+              </WebLink>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
 }

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -6,201 +6,22 @@ import type { Config } from 'jest'
 import nextJest from 'next/jest.js'
 
 const createJestConfig = nextJest({
-	// Provide the path to your Next.js app to load next.config.js and .env files in your test environment
-	dir: './',
+  // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
+  dir: './',
 })
 
 const config: Config = {
-	// Add more setup options before each test is run
-	setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
-	// All imported modules in your tests should be mocked automatically
-	// automock: false,
-
-	// Stop running tests after `n` failures
-	// bail: 0,
-
-	// The directory where Jest should store its cached dependency information
-	// cacheDirectory: "/private/var/folders/nc/7lpvrsxx3ml3nk4q7fpxs2nw0000gn/T/jest_dx",
-
-	// Automatically clear mock calls, instances, contexts and results before every test
-	clearMocks: true,
-
-	// Indicates whether the coverage information should be collected while executing the test
-	collectCoverage: true,
-
-	// An array of glob patterns indicating a set of files for which coverage information should be collected
-	// collectCoverageFrom: undefined,
-
-	// The directory where Jest should output its coverage files
-	coverageDirectory: 'coverage',
-
-	// An array of regexp pattern strings used to skip coverage collection
-	// coveragePathIgnorePatterns: [
-	//   "/node_modules/"
-	// ],
-
-	// Indicates which provider should be used to instrument code for coverage
-	coverageProvider: 'v8',
-
-	// A list of reporter names that Jest uses when writing coverage reports
-	// coverageReporters: [
-	//   "json",
-	//   "text",
-	//   "lcov",
-	//   "clover"
-	// ],
-
-	// An object that configures minimum threshold enforcement for coverage results
-	// coverageThreshold: undefined,
-
-	// A path to a custom dependency extractor
-	// dependencyExtractor: undefined,
-
-	// Make calling deprecated APIs throw helpful error messages
-	// errorOnDeprecated: false,
-
-	// The default configuration for fake timers
-	// fakeTimers: {
-	//   "enableGlobally": false
-	// },
-
-	// Force coverage collection from ignored files using an array of glob patterns
-	// forceCoverageMatch: [],
-
-	// A path to a module which exports an async function that is triggered once before all test suites
-	// globalSetup: undefined,
-
-	// A path to a module which exports an async function that is triggered once after all test suites
-	// globalTeardown: undefined,
-
-	// A set of global variables that need to be available in all test environments
-	// globals: {},
-
-	// The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
-	// maxWorkers: "50%",
-
-	// An array of directory names to be searched recursively up from the requiring module's location
-	// moduleDirectories: [
-	//   "node_modules"
-	// ],
-
-	// An array of file extensions your modules use
-	// moduleFileExtensions: [
-	//   "js",
-	//   "mjs",
-	//   "cjs",
-	//   "jsx",
-	//   "ts",
-	//   "tsx",
-	//   "json",
-	//   "node"
-	// ],
-
-	// A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-	// moduleNameMapper: {},
-
-	// An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
-	// modulePathIgnorePatterns: [],
-
-	// Activates notifications for test results
-	// notify: false,
-
-	// An enum that specifies notification mode. Requires { notify: true }
-	// notifyMode: "failure-change",
-
-	// A preset that is used as a base for Jest's configuration
-	// preset: undefined,
-
-	// Run tests from one or more projects
-	// projects: undefined,
-
-	// Use this configuration option to add custom reporters to Jest
-	// reporters: undefined,
-
-	// Automatically reset mock state before every test
-	// resetMocks: false,
-
-	// Reset the module registry before running each individual test
-	// resetModules: false,
-
-	// A path to a custom resolver
-	// resolver: undefined,
-
-	// Automatically restore mock state and implementation before every test
-	// restoreMocks: false,
-
-	// The root directory that Jest should scan for tests and modules within
-	// rootDir: undefined,
-
-	// A list of paths to directories that Jest should use to search for files in
-	// roots: [
-	//   "<rootDir>"
-	// ],
-
-	// Allows you to use a custom runner instead of Jest's default test runner
-	// runner: "jest-runner",
-
-	// The paths to modules that run some code to configure or set up the testing environment before each test
-	// setupFiles: [],
-
-	// A list of paths to modules that run some code to configure or set up the testing framework before each test
-	// setupFilesAfterEnv: [],
-
-	// The number of seconds after which a test is considered as slow and reported as such in the results.
-	// slowTestThreshold: 5,
-
-	// A list of paths to snapshot serializer modules Jest should use for snapshot testing
-	// snapshotSerializers: [],
-
-	// The test environment that will be used for testing
-	testEnvironment: 'jsdom',
-
-	// Options that will be passed to the testEnvironment
-	// testEnvironmentOptions: {},
-
-	// Adds a location field to test results
-	// testLocationInResults: false,
-
-	// The glob patterns Jest uses to detect test files
-	// testMatch: [
-	//   "**/__tests__/**/*.[jt]s?(x)",
-	//   "**/?(*.)+(spec|test).[tj]s?(x)"
-	// ],
-
-	// An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-	// testPathIgnorePatterns: [
-	//   "/node_modules/"
-	// ],
-
-	// The regexp pattern or array of patterns that Jest uses to detect test files
-	// testRegex: [],
-
-	// This option allows the use of a custom results processor
-	// testResultsProcessor: undefined,
-
-	// This option allows use of a custom test runner
-	// testRunner: "jest-circus/runner",
-
-	// A map from regular expressions to paths to transformers
-	// transform: undefined,
-
-	// An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
-	// transformIgnorePatterns: [
-	//   "/node_modules/",
-	//   "\\.pnp\\.[^\\/]+$"
-	// ],
-
-	// An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
-	// unmockedModulePathPatterns: undefined,
-
-	// Indicates whether each individual test should be reported during the run
-	// verbose: undefined,
-
-	// An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
-	// watchPathIgnorePatterns: [],
-
-	// Whether to use watchman for file crawling
-	// watchman: true,
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  clearMocks: true,
+  collectCoverage: true,
+  coverageDirectory: 'coverage',
+  coverageProvider: 'v8',
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^@/components/(.*)$': '<rootDir>/components/$1',
+    '^@/lib/(.*)$': '<rootDir>/lib/$1',
+    '^@/services/(.*)$': '<rootDir>/services/$1',
+  },
 }
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/next.config.js
+++ b/next.config.js
@@ -1,24 +1,28 @@
 /** @type {import('next').NextConfig} */
 
 module.exports = {
-	images: {
-		remotePatterns: [
-			{
-				protocol: 'https',
-				hostname: 'github.com',
-			},
-			{
-				protocol: 'https',
-				hostname: 'static-cdn.jtvnw.net',
-			},
-		],
-		dangerouslyAllowSVG: true,
-		contentDispositionType: 'attachment',
-		contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
-	},
-	experimental: {
-		outputFileTracingIncludes: {
-			'/*': ['./docs/**/*'],
-		},
-	},
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'github.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'static-cdn.jtvnw.net',
+      },
+      {
+        protocol: 'https',
+        hostname: 'avatars.githubusercontent.com',
+      },
+    ],
+    dangerouslyAllowSVG: true,
+    contentDispositionType: 'attachment',
+    contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
+  },
+  experimental: {
+    outputFileTracingIncludes: {
+      '/*': ['./docs/**/*'],
+    },
+  },
 }

--- a/services/github/adapters.ts
+++ b/services/github/adapters.ts
@@ -1,0 +1,21 @@
+import { Contributor } from '@/lib/mdx/mdx-utils'
+
+import { ContributorSchema } from './github-types'
+
+export const adaptContributorsFromMdx = (
+  contributors: Contributor[]
+): ContributorSchema[] => {
+  if (!Boolean(contributors?.length)) return []
+
+  const data = contributors?.map(({ github_username }, index) => {
+    return {
+      id: index,
+      name: github_username,
+      avatar: `https://github.com/${github_username}.png?size=80`,
+      profile: `https://github.com/${github_username}`,
+      contributions: 0,
+    }
+  })
+
+  return data
+}

--- a/services/github/get-contributors.test.ts
+++ b/services/github/get-contributors.test.ts
@@ -11,7 +11,7 @@ describe('getContributorsFromGitHub', () => {
         contributions: 0,
       },
     ]
-
+    // @ts-ignore
     global.fetch = jest.fn(() =>
       Promise.resolve({
         ok: true,

--- a/services/github/get-contributors.test.ts
+++ b/services/github/get-contributors.test.ts
@@ -1,0 +1,34 @@
+import { getContributorsFromGitHub } from './get-contributors'
+
+describe('getContributorsFromGitHub', () => {
+  test('returns correct data', async () => {
+    const mockData = [
+      {
+        id: 1,
+        name: 'nsdonato',
+        avatar: 'https://example.com/avatar1.jpg',
+        profile: 'https://example.com/profile1',
+        contributions: 0,
+      },
+    ]
+
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve([
+            {
+              id: 1,
+              login: 'nsdonato',
+              avatar_url: 'https://example.com/avatar1.jpg',
+              html_url: 'https://example.com/profile1',
+              contributions: 0,
+            },
+          ]),
+      })
+    )
+
+    const result = await getContributorsFromGitHub()
+    expect(result).toEqual(mockData)
+  })
+})

--- a/services/github/get-contributors.ts
+++ b/services/github/get-contributors.ts
@@ -1,0 +1,28 @@
+import { ContributorSchema } from './github-types'
+
+const GH_URL = 'https://api.github.com/repos/nsdonato/recursostech/contributors'
+
+export const getContributorsFromGitHub = async (): Promise<
+  ContributorSchema[] | []
+> => {
+  const res = await fetch(GH_URL, {
+    next: { revalidate: 60 },
+  })
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch API')
+  }
+
+  const response = await res.json()
+  const contributors = response.map((contributor: any) => {
+    return {
+      id: contributor.id,
+      name: contributor.login,
+      avatar: contributor.avatar_url,
+      profile: contributor.html_url,
+      contributions: contributor.contributions,
+    }
+  })
+
+  return contributors
+}

--- a/services/github/get-contributors.ts
+++ b/services/github/get-contributors.ts
@@ -6,7 +6,7 @@ export const getContributorsFromGitHub = async (): Promise<
   ContributorSchema[] | []
 > => {
   const res = await fetch(GH_URL, {
-    next: { revalidate: 60 },
+    next: { revalidate: 3600 },
   })
 
   if (!res.ok) {

--- a/services/github/github-types.ts
+++ b/services/github/github-types.ts
@@ -1,0 +1,7 @@
+export type ContributorSchema = {
+  id: number
+  name: string
+  avatar: string
+  profile: string
+  contributions: number
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
 	"compilerOptions": {
 		"target": "es5",
-		"lib": ["dom", "dom.iterable", "esnext"],
+		"lib": [
+			"dom",
+			"dom.iterable",
+			"esnext"
+		],
 		"allowJs": true,
 		"skipLibCheck": true,
 		"strict": true,
@@ -18,10 +22,26 @@
 				"name": "next",
 			},
 		],
+		"baseUrl": ".",
 		"paths": {
-			"@/*": ["./*"],
+			"@/components/*": [
+				"components/*"
+			],
+			"@/services/*": [
+				"services/*"
+			],
+			"@/lib/*": [
+				"lib/*"
+			],
 		},
 	},
-	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-	"exclude": ["node_modules"],
+	"include": [
+		"next-env.d.ts",
+		"**/*.ts",
+		"**/*.tsx",
+		".next/types/**/*.ts"
+	],
+	"exclude": [
+		"node_modules"
+	],
 }


### PR DESCRIPTION
## Descripcion ✏️
contrib.rocks no mostraba de manera actualizada los contribuidorxs del repositorio en el index de la página. Ahora se verifican desde github y se muestra correctamente sus avatars ✨. 

La llamada tiene un cache de 1 hora.

> [!IMPORTANT]
> Checklist a modo recordatorio. Tildar lo que corresponda

[] - Te agregaste como contribuidor/a, en el archivo mdx que tocaste?
[] - Verificaste que createdAt y updatedAt del recurso esten actualizados? (Si corresponde)
[] - Verifica si corresponde actualizar createdAt en menu.mdx (para secciones nuevas)
[] - Verifica si corresponde actualizar updatedAt en menu.mdx (para recursos nuevos o actualizados)
[] - Agregué un link y funciona correctamente.
[X] - Agregaste test para cubrir la nueva funcionalidad (Solo al modificar código)