### PR TITLE
fix: margin top from sidebar and main contet from header

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
       </head>
       <body>
         <Navbar />
-        <div className='grid grid-cols-1 gap-4 lg:grid-cols-6'>
+        <div className='grid grid-cols-1 gap-4 lg:grid-cols-6 mt-4'>
           <SidebarMenu className='' />
           <main className='p-4 lg:col-span-5'>{children}</main>
         </div>


### PR DESCRIPTION
## Descripcion ✏️
Agregué un poco de margen entre el contenido y el header

## Cambios visuales 🎨
Antes:
![image](https://github.com/nsdonato/recursostech/assets/7875216/c7c88b1a-ffef-40da-83ef-f81ae1e8dd1c)

Ahora:
![image](https://github.com/nsdonato/recursostech/assets/7875216/fca48120-d462-4d2d-8448-5966f7683c0c)

> [!IMPORTANT]
> Checklist a modo recordatorio. Tildar lo que corresponda

[] - Te agregaste como contribuidor/a, en el archivo mdx que tocaste?
[] - Verificaste que createdAt y updatedAt del recurso esten actualizados? (Si corresponde)
[] - Verifica si corresponde actualizar createdAt en menu.mdx (para secciones nuevas)
[] - Verifica si corresponde actualizar updatedAt en menu.mdx (para recursos nuevos o actualizados)
[] - Agregué un link y funciona correctamente.
[] - Agregaste test para cubrir la nueva funcionalidad (Solo al modificar código)