### PR TITLE
fix: :bug: se renombra en la url X por Twitter, para que no falle el CI

### DIFF
--- a/docs/mobile/streamers.mdx
+++ b/docs/mobile/streamers.mdx
@@ -29,7 +29,7 @@ submenu:
     titleCard: 'React Native, Expo.dev, Typescript, JavaScript, etc.'
     links:
       - type: 'X'
-        url: 'https://x.com/VadimNotJustDev/'
+        url: 'https://twitter.com/VadimNotJustDev/'
       - type: 'Web'
         url: 'https://www.notjust.dev/'
       - type: 'Ig'


### PR DESCRIPTION
<!-- Muchas gracias por tu tiempo ✨ y por contribuir a RecursosTech ♥️ -->
<!-- Noe @vamoacodear --->

## Descripción ✏️
<!-- Por favor, explicá brevemente de que trata este PR -->
Se renombra en la url X por Twitter, para que no falle el paso de CI que valida que no haya links rotos.
Con este cambio, no hay más errores en el CI.

![2024-02-12_15h59_16](https://github.com/nsdonato/recursostech/assets/89928062/76466e28-e970-49b7-aea8-da33f2c387da)


## Cambios visuales 🎨
<!-- Si hiciste un cambio visual, por favor subí capturas marcando los cambios así sabemos qué verificar -->

<!-- OPCIONAL -->
## Como testear? 🐛
<!-- Si es algo muy especifico que no se cubre con la ejecución de los test, por favor, contanos como testear el cambio. -->

> [!IMPORTANT]
> Checklist a modo recordatorio. Tildar lo que corresponda

- [ ] Te agregaste como contribuidor/a, en el archivo mdx que tocaste?
- [ ] Si tocaste código (no mdx), agregaste test para cubrirlo?

closes: #87 